### PR TITLE
* Fix header install step with new include sub-directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ notifications:
 os: linux
 dist: trusty
 
+env:
+  global:
+    - TMPDIR=/tmp
+
 matrix:
   include:
 
@@ -162,8 +166,8 @@ matrix:
 script:
   - cd "${TRAVIS_BUILD_DIR}"
   - mkdir build && cd build
-  - cmake .. -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-  - make
+  - cmake .. -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$TMPDIR/hfsm
+  - make install
 
   - cd "${TRAVIS_BUILD_DIR}/examples/advanced_event_handling"
   - mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ install(
 
 # Install hfsm headers.
 install(
-  DIRECTORY "${PROJECT_NAME}"
+  DIRECTORY "include/${PROJECT_NAME}"
   DESTINATION "${include_install_dir}"
 )
 


### PR DESCRIPTION
This commit also updates the .travis.yml to run `make install` instead
of just `make` so it'll catch this kind of error in the future. The
files are just installed to /tmp on the travis machine.